### PR TITLE
Fix incorrect hue/saturation blendings

### DIFF
--- a/src/non-separable-modes.ts
+++ b/src/non-separable-modes.ts
@@ -52,7 +52,7 @@ function sat (rgb: RGB) {
 }
 
 function setSat (rgb: RGB, s: number): RGB {
-  const sortedChannels = Object.keys(rgb).sort((a, b) => rgb[a as keyof RGB] - rgb[b as keyof RGB]) as [keyof RGB, keyof RGB, keyof RGB]
+  const sortedChannels = ['r', 'g', 'b'].sort((a, b) => rgb[a as keyof RGB] - rgb[b as keyof RGB]) as [keyof RGB, keyof RGB, keyof RGB]
   const cMin = sortedChannels[0]
   const cMid = sortedChannels[1]
   const cMax = sortedChannels[2]

--- a/test/test.js
+++ b/test/test.js
@@ -94,14 +94,14 @@ describe('Basics: blend { r: 250, g: 200, b: 0, a: 0.6 } with { r: 50, g: 150, b
   test('hue should return { r: 162, g: 207, b: 49, a: 0.76 }', function () {
     assert.deepStrictEqual(
       blender.hue({ r: 250, g: 200, b: 0, a: 0.6 }, { r: 50, g: 150, b: 75, a: 0.4 }),
-      { r: 162, g: 207, b: 49, a: 0.76 }
+      { r: 158, g: 207, b: 58, a: 0.76 }
     )
   })
 
   test('saturation should return { r: 209, g: 182, b: 54, a: 0.76 }', function () {
     assert.deepStrictEqual(
       blender.saturation({ r: 250, g: 200, b: 0, a: 0.6 }, { r: 50, g: 150, b: 75, a: 0.4 }),
-      { r: 209, g: 182, b: 54, a: 0.76 }
+      { r: 197, g: 188, b: 52, a: 0.76 }
     )
   })
 


### PR DESCRIPTION
This is due to a bug in the implementation where the alpha channel of two colors is additionally taken into account to determine the lowest/highest color channel value.